### PR TITLE
[no-ref] fix agentic aggregations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/arthur_common/aggregations/functions/agentic_aggregations.py
+++ b/src/arthur_common/aggregations/functions/agentic_aggregations.py
@@ -142,7 +142,7 @@ class AgenticMetricsOverTimeAggregation(SketchAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -392,7 +392,7 @@ class AgenticRelevancePassFailCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -517,7 +517,7 @@ class AgenticToolPassFailCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -638,7 +638,7 @@ class AgenticEventCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 COUNT(*) as count
             FROM {dataset.dataset_table_name}
             GROUP BY ts
@@ -695,7 +695,7 @@ class AgenticLLMCallCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -790,7 +790,7 @@ class AgenticToolSelectionAndUsageByAgentAggregation(NumericAggregationFunction)
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0

--- a/tests/unit/aggregation_functions/conftest.py
+++ b/tests/unit/aggregation_functions/conftest.py
@@ -275,9 +275,9 @@ def get_agentic_dataset_conn() -> tuple[DuckDBPyConnection, DatasetReference]:
         f"""
         CREATE TABLE {dataset_ref.dataset_table_name} (
             trace_id VARCHAR,
-            start_time BIGINT,
-            end_time BIGINT,
-            root_spans VARCHAR
+            start_time TIMESTAMP,
+            end_time TIMESTAMP,
+            root_spans JSON
         )
         """,
     )
@@ -298,8 +298,8 @@ def get_agentic_dataset_conn() -> tuple[DuckDBPyConnection, DatasetReference]:
             INSERT INTO {dataset_ref.dataset_table_name}
             VALUES (
                 '{trace['trace_id']}',
-                {trace['start_time']},
-                {trace['end_time']},
+                '{trace['start_time']}',
+                '{trace['end_time']}',
                 '{trace['root_spans']}'
             )
             """,
@@ -329,9 +329,9 @@ def get_agentic_dataset_conn_no_metrics() -> (
         f"""
         CREATE TABLE {dataset_ref.dataset_table_name} (
             trace_id VARCHAR,
-            start_time BIGINT,
-            end_time BIGINT,
-            root_spans VARCHAR
+            start_time TIMESTAMP,
+            end_time TIMESTAMP,
+            root_spans JSON
         )
         """,
     )
@@ -352,8 +352,8 @@ def get_agentic_dataset_conn_no_metrics() -> (
             INSERT INTO {dataset_ref.dataset_table_name}
             VALUES (
                 '{trace['trace_id']}',
-                {trace['start_time']},
-                {trace['end_time']},
+                '{trace['start_time']}',
+                '{trace['end_time']}',
                 '{trace['root_spans']}'
             )
             """,

--- a/tests/unit/aggregation_functions/test_agentic_data_helper.py
+++ b/tests/unit/aggregation_functions/test_agentic_data_helper.py
@@ -557,17 +557,11 @@ def create_duckdb_test_data(traces: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # Convert traces to the format expected by the aggregations
     data = []
     for trace in traces:
-        # Convert ISO 8601 timestamp to microseconds since epoch
-        start_dt = datetime.fromisoformat(trace["start_time"])
-        end_dt = datetime.fromisoformat(trace["end_time"])
-
         data.append(
             {
                 "trace_id": trace["trace_id"],
-                "start_time": int(
-                    start_dt.timestamp() * 1e6,
-                ),  # Convert to microseconds
-                "end_time": int(end_dt.timestamp() * 1e6),  # Convert to microseconds
+                "start_time": trace["start_time"],
+                "end_time": trace["end_time"],
                 "root_spans": json.dumps(trace["root_spans"]),
             },
         )


### PR DESCRIPTION
old aggregations were written assuming data used integer timestamps but real data uses actual TIMESTAMP type columns. Updating aggregations and tests with actual formats