### PR TITLE
Fix agentic aggregations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.idea
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/src/arthur_common/aggregations/functions/agentic_aggregations.py
+++ b/src/arthur_common/aggregations/functions/agentic_aggregations.py
@@ -36,7 +36,9 @@ def extract_spans_with_metrics_and_agents(root_spans):
     spans_with_metrics_and_agents = []
 
     def traverse_spans(spans, current_agent_name="unknown"):
-        for span in spans:
+        for span_str in spans:
+            span = json.loads(span_str) if type(span_str) == str else span_str
+
             # Update current agent name if this span is an AGENT
             if span.get("span_kind") == "AGENT":
                 try:
@@ -716,7 +718,9 @@ class AgenticLLMCallCountAggregation(NumericAggregationFunction):
             # Count LLM spans in the tree
             def count_llm_spans(spans):
                 count = 0
-                for span in spans:
+                for span_str in spans:
+                    span = json.loads(span_str) if type(span_str) == str else span_str
+
                     # Check if this span is an LLM span
                     if span.get("span_kind") == "LLM":
                         count += 1

--- a/src/arthur_common/aggregations/functions/agentic_aggregations.py
+++ b/src/arthur_common/aggregations/functions/agentic_aggregations.py
@@ -177,7 +177,7 @@ class AgenticMetricsOverTimeAggregation(SketchAggregationFunction):
 
                 for metric_result in metric_results:
                     metric_type = metric_result.get("metric_type")
-                    details = metric_result.get("details", {})
+                    details = json.loads(metric_result.get("details", '{}'))
 
                     if metric_type == "ToolSelection":
                         tool_selection = details.get("tool_selection", {})
@@ -423,7 +423,7 @@ class AgenticRelevancePassFailCountAggregation(NumericAggregationFunction):
 
                 for metric_result in metric_results:
                     metric_type = metric_result.get("metric_type")
-                    details = metric_result.get("details", {})
+                    details = json.loads(metric_result.get("details", '{}'))
 
                     if metric_type in ["QueryRelevance", "ResponseRelevance"]:
                         relevance_data = details.get(
@@ -548,7 +548,7 @@ class AgenticToolPassFailCountAggregation(NumericAggregationFunction):
 
                 for metric_result in metric_results:
                     if metric_result.get("metric_type") == "ToolSelection":
-                        details = metric_result.get("details", {})
+                        details = json.loads(metric_result.get("details", '{}'))
                         tool_selection = details.get("tool_selection", {})
 
                         tool_selection_score = tool_selection.get("tool_selection")
@@ -823,7 +823,7 @@ class AgenticToolSelectionAndUsageByAgentAggregation(NumericAggregationFunction)
 
                 for metric_result in metric_results:
                     if metric_result.get("metric_type") == "ToolSelection":
-                        details = metric_result.get("details", {})
+                        details = json.loads(metric_result.get("details", '{}'))
                         tool_selection = details.get("tool_selection", {})
 
                         tool_selection_score = tool_selection.get("tool_selection")

--- a/src/arthur_common/aggregations/functions/agentic_aggregations.py
+++ b/src/arthur_common/aggregations/functions/agentic_aggregations.py
@@ -142,7 +142,7 @@ class AgenticMetricsOverTimeAggregation(SketchAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -392,7 +392,7 @@ class AgenticRelevancePassFailCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -517,7 +517,7 @@ class AgenticToolPassFailCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -638,7 +638,7 @@ class AgenticEventCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 COUNT(*) as count
             FROM {dataset.dataset_table_name}
             GROUP BY ts
@@ -695,7 +695,7 @@ class AgenticLLMCallCountAggregation(NumericAggregationFunction):
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0
@@ -790,7 +790,7 @@ class AgenticToolSelectionAndUsageByAgentAggregation(NumericAggregationFunction)
         results = ddb_conn.sql(
             f"""
             SELECT
-                time_bucket(INTERVAL '5 minutes', to_timestamp(start_time / 1000000)) as ts,
+                time_bucket(INTERVAL '5 minutes', start_time) as ts,
                 root_spans
             FROM {dataset.dataset_table_name}
             WHERE root_spans IS NOT NULL AND length(root_spans) > 0

--- a/tests/unit/aggregation_functions/conftest.py
+++ b/tests/unit/aggregation_functions/conftest.py
@@ -275,9 +275,9 @@ def get_agentic_dataset_conn() -> tuple[DuckDBPyConnection, DatasetReference]:
         f"""
         CREATE TABLE {dataset_ref.dataset_table_name} (
             trace_id VARCHAR,
-            start_time BIGINT,
-            end_time BIGINT,
-            root_spans VARCHAR
+            start_time TIMESTAMP,
+            end_time TIMESTAMP,
+            root_spans JSON
         )
         """,
     )
@@ -298,8 +298,8 @@ def get_agentic_dataset_conn() -> tuple[DuckDBPyConnection, DatasetReference]:
             INSERT INTO {dataset_ref.dataset_table_name}
             VALUES (
                 '{trace['trace_id']}',
-                {trace['start_time']},
-                {trace['end_time']},
+                '{trace['start_time']}',
+                '{trace['end_time']}',
                 '{trace['root_spans']}'
             )
             """,
@@ -329,9 +329,9 @@ def get_agentic_dataset_conn_no_metrics() -> (
         f"""
         CREATE TABLE {dataset_ref.dataset_table_name} (
             trace_id VARCHAR,
-            start_time BIGINT,
-            end_time BIGINT,
-            root_spans VARCHAR
+            start_time TIMESTAMP,
+            end_time TIMESTAMP,
+            root_spans JSON
         )
         """,
     )
@@ -352,8 +352,8 @@ def get_agentic_dataset_conn_no_metrics() -> (
             INSERT INTO {dataset_ref.dataset_table_name}
             VALUES (
                 '{trace['trace_id']}',
-                {trace['start_time']},
-                {trace['end_time']},
+                '{trace['start_time']}',
+                '{trace['end_time']}',
                 '{trace['root_spans']}'
             )
             """,

--- a/tests/unit/aggregation_functions/test_agentic_data_helper.py
+++ b/tests/unit/aggregation_functions/test_agentic_data_helper.py
@@ -46,36 +46,36 @@ def create_metric_results(
     return [
         {
             "metric_type": "ToolSelection",
-            "details": {
+            "details": json.dumps({
                 "tool_selection": {
                     "tool_selection": tool_selection,
                     "tool_selection_reason": f"Tool selection reason (score={tool_selection})",
                     "tool_usage": tool_usage,
                     "tool_usage_reason": f"Tool usage reason (score={tool_usage})",
                 },
-            },
+            }),
         },
         {
             "metric_type": "QueryRelevance",
-            "details": {
+            "details": json.dumps({
                 "query_relevance": {
                     "llm_relevance_score": qrelevance,
                     "reranker_relevance_score": qrelevance + 0.02,
                     "bert_f_score": qrelevance - 0.05,
                     "reason": f"Query relevance reason (score={qrelevance})",
                 },
-            },
+            }),
         },
         {
             "metric_type": "ResponseRelevance",
-            "details": {
+            "details": json.dumps({
                 "response_relevance": {
                     "llm_relevance_score": resprelevance,
                     "reranker_relevance_score": resprelevance + 0.03,
                     "bert_f_score": resprelevance - 0.08,
                     "reason": f"Response relevance reason (score={resprelevance})",
                 },
-            },
+            }),
         },
     ]
 

--- a/tests/unit/aggregation_functions/test_agentic_data_helper.py
+++ b/tests/unit/aggregation_functions/test_agentic_data_helper.py
@@ -557,17 +557,11 @@ def create_duckdb_test_data(traces: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # Convert traces to the format expected by the aggregations
     data = []
     for trace in traces:
-        # Convert ISO 8601 timestamp to microseconds since epoch
-        start_dt = datetime.fromisoformat(trace["start_time"])
-        end_dt = datetime.fromisoformat(trace["end_time"])
-
         data.append(
             {
                 "trace_id": trace["trace_id"],
-                "start_time": int(
-                    start_dt.timestamp() * 1e6,
-                ),  # Convert to microseconds
-                "end_time": int(end_dt.timestamp() * 1e6),  # Convert to microseconds
+                "start_time": trace["start_time"],
+                "end_time": trace["end_time"],
                 "root_spans": json.dumps(trace["root_spans"]),
             },
         )

--- a/tests/unit/aggregation_functions/test_agentic_data_helper.py
+++ b/tests/unit/aggregation_functions/test_agentic_data_helper.py
@@ -95,7 +95,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                 base_time + timedelta(minutes=0, seconds=30, microseconds=200000)
             ).isoformat(),
             "root_spans": [
-                {
+                json.dumps({
                     "id": "chain-001",
                     "span_kind": "CHAIN",
                     "start_time": (
@@ -137,7 +137,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                             "children": [],
                         },
                     ],
-                },
+                }),
             ],
         },
         # Trace 2: chain->agent->llm with all metrics (pass)
@@ -150,7 +150,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                 base_time + timedelta(minutes=5, seconds=30, microseconds=400000)
             ).isoformat(),
             "root_spans": [
-                {
+                json.dumps({
                     "id": "chain-002",
                     "span_kind": "CHAIN",
                     "start_time": (base_time + timedelta(minutes=5)).isoformat(),
@@ -212,7 +212,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                             ],
                         },
                     ],
-                },
+                }),
             ],
         },
         # Trace 3: chain->agent->chain->llm with all metrics (pass)
@@ -225,7 +225,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                 base_time + timedelta(minutes=10, seconds=30, microseconds=600000)
             ).isoformat(),
             "root_spans": [
-                {
+                json.dumps({
                     "id": "chain-003",
                     "span_kind": "CHAIN",
                     "start_time": (base_time + timedelta(minutes=10)).isoformat(),
@@ -308,7 +308,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                             ],
                         },
                     ],
-                },
+                }),
             ],
         },
         # Trace 4: agent->llm with all metrics (fail)
@@ -321,7 +321,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                 base_time + timedelta(minutes=15, seconds=30, microseconds=800000)
             ).isoformat(),
             "root_spans": [
-                {
+                json.dumps({
                     "id": "agent-004",
                     "span_kind": "AGENT",
                     "start_time": (base_time + timedelta(minutes=15)).isoformat(),
@@ -360,7 +360,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                             "children": [],
                         },
                     ],
-                },
+                }),
             ],
         },
         # Trace 5: chain->llm with all metrics (fail)
@@ -373,7 +373,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                 base_time + timedelta(minutes=20, seconds=30, microseconds=950000)
             ).isoformat(),
             "root_spans": [
-                {
+                json.dumps({
                     "id": "chain-005",
                     "span_kind": "CHAIN",
                     "start_time": (base_time + timedelta(minutes=20)).isoformat(),
@@ -412,7 +412,7 @@ def get_hardcoded_traces_with_metrics() -> List[Dict[str, Any]]:
                             "children": [],
                         },
                     ],
-                },
+                }),
             ],
         },
     ]
@@ -433,7 +433,7 @@ def get_hardcoded_traces_without_metrics() -> List[Dict[str, Any]]:
                 base_time + timedelta(minutes=0, seconds=30, microseconds=250000)
             ).isoformat(),
             "root_spans": [
-                {
+                json.dumps({
                     "id": "chain-no-metrics-001",
                     "span_kind": "CHAIN",
                     "start_time": (
@@ -474,7 +474,7 @@ def get_hardcoded_traces_without_metrics() -> List[Dict[str, Any]]:
                             "children": [],
                         },
                     ],
-                },
+                }),
             ],
         },
         # Trace 2: chain->agent->llm without metrics
@@ -487,7 +487,7 @@ def get_hardcoded_traces_without_metrics() -> List[Dict[str, Any]]:
                 base_time + timedelta(minutes=5, seconds=30, microseconds=450000)
             ).isoformat(),
             "root_spans": [
-                {
+                json.dumps({
                     "id": "chain-no-metrics-002",
                     "span_kind": "CHAIN",
                     "start_time": (base_time + timedelta(minutes=5)).isoformat(),
@@ -546,7 +546,7 @@ def get_hardcoded_traces_without_metrics() -> List[Dict[str, Any]]:
                             ],
                         },
                     ],
-                },
+                }),
             ],
         },
     ]


### PR DESCRIPTION
1. old aggregations were written assuming data used integer timestamps but real data uses actual TIMESTAMP type columns. Updating aggregations and tests with actual formats
2. old aggregations and tests assumed `root_spans` were dicts, when actually they are json string
3. old aggregations assumed `details` object was a dict, but actually is a json string
4. added agent_name dimension to some metrics missing it
