### PR TITLE
[no-ref] fix large trace loading into duckdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@ pip install arthur-common
 
 ## Requirements
 
-- Python 3.12
+- Python 3.13
 
 ## Development
 
 To set up the development environment, ensure you have [Poetry](https://python-poetry.org/) installed, then run:
 
 ```bash
-poetry env use 3.12
+poetry env use 3.13
 poetry install
 ```
 

--- a/src/arthur_common/aggregations/aggregator.py
+++ b/src/arthur_common/aggregations/aggregator.py
@@ -172,7 +172,9 @@ class SketchAggregationFunction(AggregationFunction, ABC):
         groups = data.groupby(dim_columns, dropna=False)
         for _, group in groups:
             calculated_metrics.append(
-                SketchAggregationFunction._group_to_series(group, timestamp_col, dim_columns, value_col),
+                SketchAggregationFunction._group_to_series(
+                    group, timestamp_col, dim_columns, value_col
+                ),
             )
 
         return calculated_metrics

--- a/src/arthur_common/tools/duckdb_data_loader.py
+++ b/src/arthur_common/tools/duckdb_data_loader.py
@@ -17,6 +17,8 @@ from arthur_common.models.schema_definitions import (
 )
 
 
+MAX_JSON_OBJECT_SIZE=1024 * 1024 * 1024  # 1GB
+
 class ColumnFormat(BaseModel):
     source_name: str
     alias: str
@@ -104,9 +106,9 @@ class DuckDBOperator:
             stringified_schema = ", ".join([f"{kv}" for kv in key_value_pairs])
             stringified_schema = f"{{ {stringified_schema} }}"
 
-            read_stmt = f"read_json('memory://inferences.json', format='array', columns={stringified_schema})"
+            read_stmt = f"read_json('memory://inferences.json', format='array', columns={stringified_schema}, maximum_object_size={MAX_JSON_OBJECT_SIZE})"
         else:
-            read_stmt = "read_json_auto('memory://inferences.json')"
+            read_stmt = f"read_json_auto('memory://inferences.json', maximum_object_size={MAX_JSON_OBJECT_SIZE})"
 
         conn.sql(
             f"CREATE OR REPLACE TEMP TABLE {table_name} AS SELECT * FROM {read_stmt}",

--- a/src/arthur_common/tools/duckdb_data_loader.py
+++ b/src/arthur_common/tools/duckdb_data_loader.py
@@ -16,8 +16,8 @@ from arthur_common.models.schema_definitions import (
     DType,
 )
 
+MAX_JSON_OBJECT_SIZE = 1024 * 1024 * 1024  # 1GB
 
-MAX_JSON_OBJECT_SIZE=1024 * 1024 * 1024  # 1GB
 
 class ColumnFormat(BaseModel):
     source_name: str

--- a/tests/unit/tools/test_duck_db_operations.py
+++ b/tests/unit/tools/test_duck_db_operations.py
@@ -62,10 +62,10 @@ df3 = pd.DataFrame(test_data_2)
     [(df1, df2, "inner", 2), (df1, df2, "left_outer", 3), (df1, df3, "inner", 2)],
 )
 def test_dataset_join_kinds(
-    left_df: pd.DataFrame,
-    right_df: pd.DataFrame,
-    join_kind: str,
-    expected_count: int,
+        left_df: pd.DataFrame,
+        right_df: pd.DataFrame,
+        join_kind: str,
+        expected_count: int,
 ):
     conn = DuckDBOperator.load_data_to_duckdb(left_df, table_name="left_table")
     conn = DuckDBOperator.load_data_to_duckdb(
@@ -386,8 +386,8 @@ data_rows_2 = [
     [(pd.DataFrame(data_row_1), pd.DataFrame(data_row_2)), (data_rows, data_rows_2)],
 )
 def test_simple_load_data_with_schema_special_character_names(
-    data1: pd.DataFrame | list[dict[str, Any]],
-    data2: pd.DataFrame | list[dict[str, Any]],
+        data1: pd.DataFrame | list[dict[str, Any]],
+        data2: pd.DataFrame | list[dict[str, Any]],
 ):
     schema = DatasetSchema(
         alias_mask={},
@@ -432,3 +432,23 @@ def test_simple_load_data_with_schema_special_character_names(
 
     res = conn.sql("SELECT count(*) FROM joined").fetchall()
     assert res[0][0] == 2
+
+
+def test_simple_load_data_with_large_json_object():
+    data = [
+        {
+            "id": "991ff637-2c13-4289-ba17-a23c1c2b20b8",
+            "timestamp": "2024-07-28T13:46:12+0000",
+            "long_field": "a" * 1024 * 1024 * 100,  # 100MB
+        },
+    ]
+
+    conn = DuckDBOperator.load_data_to_duckdb(data)
+    results = conn.sql("SELECT * FROM inferences").fetchall()
+    assert len(results) == 1
+
+    # Assert values took on the type defined in the schema, (uuid, datetime) and not the raw types (str, str)
+    for row in results:
+        assert type(row[0]) == UUID
+        assert type(row[1]) == str
+        assert type(row[2]) == str

--- a/tests/unit/tools/test_duck_db_operations.py
+++ b/tests/unit/tools/test_duck_db_operations.py
@@ -434,7 +434,33 @@ def test_simple_load_data_with_schema_special_character_names(
     assert res[0][0] == 2
 
 
-def test_simple_load_data_with_large_json_object():
+@pytest.mark.parametrize(
+    "schema",
+    [
+        DatasetSchema(
+            alias_mask={},
+            columns=[
+                DatasetColumn(
+                    id=uuid4(),
+                    source_name="id",
+                    definition=DatasetScalarType(id=uuid4(), dtype=DType.UUID),
+                ),
+                DatasetColumn(
+                    id=uuid4(),
+                    source_name="timestamp",
+                    definition=DatasetScalarType(id=uuid4(), dtype=DType.TIMESTAMP),
+                ),
+                DatasetColumn(
+                    id=uuid4(),
+                    source_name="long_field",
+                    definition=DatasetScalarType(id=uuid4(), dtype=DType.STRING),
+                ),
+            ],
+        ),
+        None,
+    ],
+)
+def test_simple_load_data_with_large_json_object(schema):
     data = [
         {
             "id": "991ff637-2c13-4289-ba17-a23c1c2b20b8",
@@ -443,12 +469,12 @@ def test_simple_load_data_with_large_json_object():
         },
     ]
 
-    conn = DuckDBOperator.load_data_to_duckdb(data)
+    conn = DuckDBOperator.load_data_to_duckdb(data, schema=schema)
     results = conn.sql("SELECT * FROM inferences").fetchall()
     assert len(results) == 1
 
-    # Assert values took on the type defined in the schema, (uuid, datetime) and not the raw types (str, str)
-    for row in results:
-        assert type(row[0]) == UUID
-        assert type(row[1]) == str
-        assert type(row[2]) == str
+    if schema is not None:
+        for row in results:
+            assert type(row[0]) == UUID
+            assert type(row[1]) == datetime
+            assert type(row[2]) == str

--- a/tests/unit/tools/test_duck_db_operations.py
+++ b/tests/unit/tools/test_duck_db_operations.py
@@ -62,10 +62,10 @@ df3 = pd.DataFrame(test_data_2)
     [(df1, df2, "inner", 2), (df1, df2, "left_outer", 3), (df1, df3, "inner", 2)],
 )
 def test_dataset_join_kinds(
-        left_df: pd.DataFrame,
-        right_df: pd.DataFrame,
-        join_kind: str,
-        expected_count: int,
+    left_df: pd.DataFrame,
+    right_df: pd.DataFrame,
+    join_kind: str,
+    expected_count: int,
 ):
     conn = DuckDBOperator.load_data_to_duckdb(left_df, table_name="left_table")
     conn = DuckDBOperator.load_data_to_duckdb(
@@ -386,8 +386,8 @@ data_rows_2 = [
     [(pd.DataFrame(data_row_1), pd.DataFrame(data_row_2)), (data_rows, data_rows_2)],
 )
 def test_simple_load_data_with_schema_special_character_names(
-        data1: pd.DataFrame | list[dict[str, Any]],
-        data2: pd.DataFrame | list[dict[str, Any]],
+    data1: pd.DataFrame | list[dict[str, Any]],
+    data2: pd.DataFrame | list[dict[str, Any]],
 ):
     schema = DatasetSchema(
         alias_mask={},


### PR DESCRIPTION
Previously, loading large agentic traces into duckDB would fail with an error like the following:

```
  File "/home/arthur/venv/lib/python3.13/site-packages/arthur_common/tools/duckdb_data_loader.py", line 111, in _load_unstructured_data
    conn.sql(
    ~~~~~~~~^
        f"CREATE OR REPLACE TEMP TABLE {table_name} AS SELECT * FROM {read_stmt}",
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
duckdb.duckdb.InvalidInputException: Invalid Input Error: "maximum_object_size" of 16777216 bytes exceeded while reading file "memory:///inferences.json" (>33554428 bytes).
 Try increasing "maximum_object_size".
```

This MR increases the maximum object size to 1GB to allow for larger trace sizes.