### PR TITLE
API consolidation: Fix config type bindings

### DIFF
--- a/src/arthur_common/models/request_schemas.py
+++ b/src/arthur_common/models/request_schemas.py
@@ -49,9 +49,14 @@ class NewRuleRequest(BaseModel):
         description="Boolean value to enable or disable the rule for llm response",
         examples=[False],
     )
-    config: Optional[
-        Union[RegexConfig, KeywordsConfig, ToxicityConfig, PIIConfig, ExamplesConfig]
-    ] = Field(description="Config for the rule", default=None)
+    config: (
+            KeywordsConfig
+            | RegexConfig
+            | ExamplesConfig
+            | ToxicityConfig
+            | PIIConfig
+            | None
+    ) = Field(description="Config of the rule", default=None)
 
     model_config = ConfigDict(
         json_schema_extra={


### PR DESCRIPTION
Relevant to here: https://gitlab.com/ArthurAI/arthur-scope/-/merge_requests/1319#note_2728191929

TLDR: While picking up the new generated bindings from the arthur-common changes made in the API consolidation MR, I realized that using the Union type here confused the generator into generating two type bindings (`Config` and `Config1`). This is because the OpenAPI generator can't figure out with the union types that this can be generated to share a type binding with the same config object here: https://github.com/arthur-ai/arthur-common/blob/c4e053a855f526e31190c2fb5a94cc2cace73a66/src/arthur_common/models/response_schemas.py#L55

Updating this so that the generated client only has `Config` in its type outputs instead of `Config` and `Config1`. This is in line with how the object was created in the GenAi engine client originally—I'm not sure why it got changed in the consolidation MR:
<img width="924" height="766" alt="Screenshot 2025-09-16 at 11 22 33 AM" src="https://github.com/user-attachments/assets/8347257a-fb25-4b9b-86ad-eaea211124a1" />
This screenshot is with the removal of the object from the GenAI engine in the original PR. Notice the difference in the Union vs non-Union typing.
