### PR TITLE
UP-2994: Expect escaped column names from the ML engine

### DIFF
--- a/src/arthur_common/aggregations/functions/categorical_count.py
+++ b/src/arthur_common/aggregations/functions/categorical_count.py
@@ -18,7 +18,8 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier, escape_str_literal
+
+from arthur_common.tools.duckdb_data_loader import unescape_identifier, escape_str_literal
 
 
 class CategoricalCountAggregationFunction(NumericAggregationFunction):
@@ -93,30 +94,25 @@ class CategoricalCountAggregationFunction(NumericAggregationFunction):
         ] = None,
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
-            select time_bucket(INTERVAL '5 minutes', {timestamp_col_escaped}) as ts, \
+            select time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts, \
                 count(*) as count, \
-                {categorical_col_escaped} as category, \
-                {categorical_col_name_escaped} as column_name \
+                {categorical_col} as category, \
+                {categorical_col_name_unescaped} as column_name \
                 from {dataset.dataset_table_name} \
                 where ts is not null \
                 group by ts, category
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        timestamp_col_escaped = escape_identifier(timestamp_col)
-        categorical_col_escaped = escape_identifier(categorical_col)
-        categorical_col_name_escaped = escape_str_literal(categorical_col)
+        categorical_col_name_unescaped = escape_str_literal(unescape_identifier(categorical_col))
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {timestamp_col_escaped}) as ts",
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
             f"count(*) as count",
-            f"{categorical_col_escaped} as category",
-            f"{categorical_col_name_escaped} as column_name",
-        ] + escaped_segmentation_cols
-        all_group_by_cols = ["ts", "category"] + escaped_segmentation_cols
+            f"{categorical_col} as category",
+            f"{categorical_col_name_unescaped} as column_name",
+        ] + segmentation_cols
+        all_group_by_cols = ["ts", "category"] + segmentation_cols
         extra_dims = ["column_name", "category"]
 
         # build query
@@ -129,10 +125,11 @@ class CategoricalCountAggregationFunction(NumericAggregationFunction):
 
         results = ddb_conn.sql(count_query).df()
 
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         series = self.group_query_results_to_numeric_metrics(
             results,
             "count",
-            segmentation_cols + extra_dims,
+            unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         metric = self.series_to_metric(self.METRIC_NAME, series)

--- a/src/arthur_common/aggregations/functions/confusion_matrix.py
+++ b/src/arthur_common/aggregations/functions/confusion_matrix.py
@@ -20,7 +20,8 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier, escape_str_literal
+
+from arthur_common.tools.duckdb_data_loader import unescape_identifier, escape_str_literal
 
 
 class ConfusionMatrixAggregationFunction(NumericAggregationFunction):
@@ -78,11 +79,11 @@ class ConfusionMatrixAggregationFunction(NumericAggregationFunction):
             Without segmentation, this is the query:
                 WITH normalized_data AS (
                     SELECT
-                        {escaped_timestamp_col} AS timestamp,
-                        {prediction_normalization_case.replace('value', escaped_prediction_col)} AS prediction,
-                        {gt_normalization_case.replace('value', escaped_gt_values_col)} AS actual_value
+                        {timestamp_col} AS timestamp,
+                        {prediction_normalization_case.replace('value', prediction_col)} AS prediction,
+                        {gt_normalization_case.replace('value', gt_values_col)} AS actual_value
                     FROM {dataset.dataset_table_name}
-                    WHERE {escaped_timestamp_col} IS NOT NULL
+                    WHERE {timestamp_col} IS NOT NULL
                 )
                 SELECT
                     time_bucket(INTERVAL '5 minutes', timestamp) AS ts,
@@ -90,34 +91,29 @@ class ConfusionMatrixAggregationFunction(NumericAggregationFunction):
                     SUM(CASE WHEN prediction != actual_value AND actual_value = 0 THEN 1 ELSE 0 END) AS false_positive_count,
                     SUM(CASE WHEN prediction != actual_value AND actual_value = 1 THEN 1 ELSE 0 END) AS false_negative_count,
                     SUM(CASE WHEN prediction = actual_value AND actual_value = 0 THEN 1 ELSE 0 END) AS true_negative_count,
-                    {escaped_prediction_col_name} as prediction_column_name
+                    {unescaped_prediction_col_name} as prediction_column_name
                 FROM normalized_data
                 GROUP BY ts
                 ORDER BY ts
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_prediction_col = escape_identifier(prediction_col)
-        escaped_prediction_col_name = escape_str_literal(prediction_col)
-        escaped_gt_values_col = escape_identifier(gt_values_col)
+        unescaped_prediction_col_name = escape_str_literal(unescape_identifier(prediction_col))
+
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         first_subquery_select_cols = [
-            f"{escaped_timestamp_col} AS timestamp",
-            f"{prediction_normalization_case.replace('value', escaped_prediction_col)} AS prediction",
-            f"{gt_normalization_case.replace('value', escaped_gt_values_col)} AS actual_value",
-        ] + escaped_segmentation_cols
+            f"{timestamp_col} AS timestamp",
+            f"{prediction_normalization_case.replace('value', prediction_col)} AS prediction",
+            f"{gt_normalization_case.replace('value', gt_values_col)} AS actual_value",
+        ] + segmentation_cols
         second_subquery_select_cols = [
             "time_bucket(INTERVAL '5 minutes', timestamp) AS ts",
             "SUM(CASE WHEN prediction = actual_value AND actual_value = 1 THEN 1 ELSE 0 END) AS true_positive_count",
             "SUM(CASE WHEN prediction != actual_value AND actual_value = 0 THEN 1 ELSE 0 END) AS false_positive_count",
             "SUM(CASE WHEN prediction != actual_value AND actual_value = 1 THEN 1 ELSE 0 END) AS false_negative_count",
             "SUM(CASE WHEN prediction = actual_value AND actual_value = 0 THEN 1 ELSE 0 END) AS true_negative_count",
-            f"{escaped_prediction_col_name} as prediction_column_name",
-        ] + escaped_segmentation_cols
-        second_subquery_group_by_cols = ["ts"] + escaped_segmentation_cols
+            f"{unescaped_prediction_col_name} as prediction_column_name",
+        ] + segmentation_cols
+        second_subquery_group_by_cols = ["ts"] + segmentation_cols
         extra_dims = ["prediction_column_name"]
 
         # build query
@@ -125,7 +121,7 @@ class ConfusionMatrixAggregationFunction(NumericAggregationFunction):
                 WITH normalized_data AS (
                     SELECT {", ".join(first_subquery_select_cols)}
                     FROM {dataset.dataset_table_name}
-                    WHERE {escaped_timestamp_col} IS NOT NULL
+                    WHERE {timestamp_col} IS NOT NULL
                 )
                 SELECT {", ".join(second_subquery_select_cols)}
                 FROM normalized_data
@@ -135,28 +131,29 @@ class ConfusionMatrixAggregationFunction(NumericAggregationFunction):
 
         results = ddb_conn.sql(confusion_matrix_query).df()
 
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         tp = self.group_query_results_to_numeric_metrics(
             results,
             "true_positive_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         fp = self.group_query_results_to_numeric_metrics(
             results,
             "false_positive_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         fn = self.group_query_results_to_numeric_metrics(
             results,
             "false_negative_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         tn = self.group_query_results_to_numeric_metrics(
             results,
             "true_negative_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         tp_metric = self.series_to_metric(self.TRUE_POSITIVE_METRIC_NAME, tp)
@@ -243,9 +240,8 @@ class BinaryClassifierIntBoolConfusionMatrixAggregationFunction(
         ] = None,
     ) -> list[NumericMetric]:
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_prediction_col = escape_identifier(prediction_col)
         # Get the type of prediction column
-        type_query = f"SELECT typeof({escaped_prediction_col}) as col_type FROM {dataset.dataset_table_name} LIMIT 1"
+        type_query = f"SELECT typeof({prediction_col}) as col_type FROM {dataset.dataset_table_name} LIMIT 1"
         res = ddb_conn.sql(type_query).fetchone()
         # As long as this column exists, we should be able to get the type. This is here to make mypy happy.
         if not res:
@@ -476,7 +472,6 @@ class BinaryClassifierProbabilityThresholdConfusionMatrixAggregationFunction(
             ),
         ] = None,
     ) -> list[NumericMetric]:
-        escaped_gt_values_col = escape_identifier(gt_values_col)
         prediction_normalization_case = f"""
                 CASE
                     WHEN value >= {threshold} THEN 1
@@ -485,7 +480,7 @@ class BinaryClassifierProbabilityThresholdConfusionMatrixAggregationFunction(
                 END
                 """
 
-        type_query = f"SELECT typeof({escaped_gt_values_col}) as col_type FROM {dataset.dataset_table_name} LIMIT 1"
+        type_query = f"SELECT typeof({gt_values_col}) as col_type FROM {dataset.dataset_table_name} LIMIT 1"
         res = ddb_conn.sql(type_query).fetchone()
         # As long as this column exists, we should be able to get the type. This is here to make mypy happy.
         if not res:

--- a/src/arthur_common/aggregations/functions/inference_count.py
+++ b/src/arthur_common/aggregations/functions/inference_count.py
@@ -18,7 +18,7 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier
+from arthur_common.tools.duckdb_data_loader import unescape_identifier
 
 
 class InferenceCountAggregationFunction(NumericAggregationFunction):
@@ -80,23 +80,19 @@ class InferenceCountAggregationFunction(NumericAggregationFunction):
         ] = None,
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
-            select time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts, \
+            select time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts, \
                     count(*) as count \
                     from {dataset.dataset_table_name} \
                     group by ts \
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts",
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
             f"count(*) as count",
-        ] + escaped_segmentation_cols
-        all_group_by_cols = ["ts"] + escaped_segmentation_cols
+        ] + segmentation_cols
+        all_group_by_cols = ["ts"] + segmentation_cols
 
         # build query
         count_query = f"""
@@ -106,10 +102,11 @@ class InferenceCountAggregationFunction(NumericAggregationFunction):
         """
 
         results = ddb_conn.sql(count_query).df()
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         series = self.group_query_results_to_numeric_metrics(
             results,
             "count",
-            segmentation_cols,
+            unescaped_segmentation_cols,
             "ts",
         )
         metric = self.series_to_metric(self.METRIC_NAME, series)

--- a/src/arthur_common/aggregations/functions/inference_count_by_class.py
+++ b/src/arthur_common/aggregations/functions/inference_count_by_class.py
@@ -20,7 +20,7 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier
+from arthur_common.tools.duckdb_data_loader import unescape_identifier
 
 
 class BinaryClassifierCountByClassAggregationFunction(NumericAggregationFunction):
@@ -100,31 +100,26 @@ class BinaryClassifierCountByClassAggregationFunction(NumericAggregationFunction
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
         SELECT
-            time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts,
-            {escaped_pred_col} as prediction,
+            time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts,
+            {prediction_col} as prediction,
             COUNT(*) as count
         FROM {dataset.dataset_table_name}
         GROUP BY
             ts,
             -- group by raw column name instead of alias in select
             -- in case table has a column called 'prediction'
-            {escaped_pred_col}
+            {prediction_col}
         ORDER BY ts
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_pred_col = escape_identifier(prediction_col)
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts",
-            f"{escaped_pred_col} as prediction",
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
+            f"{prediction_col} as prediction",
             f"COUNT(*) as count",
-        ] + escaped_segmentation_cols
-        all_group_by_cols = ["ts", f"{escaped_pred_col}"] + escaped_segmentation_cols
+        ] + segmentation_cols
+        all_group_by_cols = ["ts", f"{prediction_col}"] + segmentation_cols
         extra_dims = ["prediction"]
 
         # build query
@@ -137,10 +132,11 @@ class BinaryClassifierCountByClassAggregationFunction(NumericAggregationFunction
 
         result = ddb_conn.sql(query).df()
 
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         series = self.group_query_results_to_numeric_metrics(
             result,
             "count",
-            segmentation_cols + extra_dims,
+            unescaped_segmentation_cols + extra_dims,
             "ts",
         )
         metric = self.series_to_metric(self._metric_name(), series)
@@ -248,34 +244,29 @@ class BinaryClassifierCountThresholdClassAggregationFunction(
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
             SELECT
-            time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts,
-            CASE WHEN {escaped_prediction_col} >= {threshold} THEN '{true_label}' ELSE '{false_label}' END as prediction,
+            time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts,
+            CASE WHEN {prediction_col} >= {threshold} THEN '{true_label}' ELSE '{false_label}' END as prediction,
             COUNT(*) as count
         FROM {dataset.dataset_table_name}
         GROUP BY
             ts,
             -- group by raw column name instead of alias in select
             -- in case table has a column called 'prediction'
-            {escaped_prediction_col}
+            {prediction_col}
         ORDER BY ts
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_prediction_col = escape_identifier(prediction_col)
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts",
-            f"CASE WHEN {escaped_prediction_col} >= {threshold} THEN '{true_label}' ELSE '{false_label}' END as prediction",
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
+            f"CASE WHEN {prediction_col} >= {threshold} THEN '{true_label}' ELSE '{false_label}' END as prediction",
             f"COUNT(*) as count",
-        ] + escaped_segmentation_cols
+        ] + segmentation_cols
         all_group_by_cols = [
             "ts",
-            f"{escaped_prediction_col}",
-        ] + escaped_segmentation_cols
+            f"{prediction_col}",
+        ] + segmentation_cols
         extra_dims = ["prediction"]
 
         query = f"""
@@ -287,10 +278,11 @@ class BinaryClassifierCountThresholdClassAggregationFunction(
 
         result = ddb_conn.sql(query).df()
 
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         series = self.group_query_results_to_numeric_metrics(
             result,
             "count",
-            segmentation_cols + extra_dims,
+            unescaped_segmentation_cols + extra_dims,
             "ts",
         )
         metric = self.series_to_metric(self._metric_name(), series)

--- a/src/arthur_common/aggregations/functions/inference_null_count.py
+++ b/src/arthur_common/aggregations/functions/inference_null_count.py
@@ -19,7 +19,7 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier
+from arthur_common.tools.duckdb_data_loader import unescape_identifier
 
 
 class InferenceNullCountAggregationFunction(NumericAggregationFunction):
@@ -90,44 +90,40 @@ class InferenceNullCountAggregationFunction(NumericAggregationFunction):
         ] = None,
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
-                select time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts, \
+                select time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts, \
                 count(*) as count \
-                from {dataset.dataset_table_name} where {escaped_nullable_col} is null \
+                from {dataset.dataset_table_name} where {nullable_col} is null \
                 group by ts \
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_nullable_col = escape_identifier(nullable_col)
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts",
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
             f"count(*) as count",
-        ] + escaped_segmentation_cols
-        all_group_by_cols = ["ts"] + escaped_segmentation_cols
+        ] + segmentation_cols
+        all_group_by_cols = ["ts"] + segmentation_cols
 
         # build query
         count_query = f"""
             select {", ".join(all_select_clause_cols)}
             from {dataset.dataset_table_name}
-            where {escaped_nullable_col} is null
+            where {nullable_col} is null
             group by {", ".join(all_group_by_cols)}
         """
 
         results = ddb_conn.sql(count_query).df()
 
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         series = self.group_query_results_to_numeric_metrics(
             results,
             "count",
-            segmentation_cols,
+            unescaped_segmentation_cols,
             "ts",
         )
         # preserve dimension that identifies the name of the nullable column used for the aggregation
         for point in series:
-            point.dimensions.append(Dimension(name="column_name", value=nullable_col))
+            point.dimensions.append(Dimension(name="column_name", value=unescape_identifier(nullable_col)))
 
         metric = self.series_to_metric(self.METRIC_NAME, series)
         return [metric]

--- a/src/arthur_common/aggregations/functions/mean_absolute_error.py
+++ b/src/arthur_common/aggregations/functions/mean_absolute_error.py
@@ -19,7 +19,7 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier
+from arthur_common.tools.duckdb_data_loader import unescape_identifier
 
 
 class MeanAbsoluteErrorAggregationFunction(NumericAggregationFunction):
@@ -111,50 +111,45 @@ class MeanAbsoluteErrorAggregationFunction(NumericAggregationFunction):
         ] = None,
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
-                SELECT time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts, \
-                SUM(ABS({escaped_prediction_col} - {escaped_ground_truth_col})) as ae, \
+                SELECT time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts, \
+                SUM(ABS({prediction_col} - {ground_truth_col})) as ae, \
                 COUNT(*) as count \
                 FROM {dataset.dataset_table_name} \
-                WHERE {escaped_prediction_col} IS NOT NULL \
-                AND {escaped_ground_truth_col} IS NOT NULL \
+                WHERE {prediction_col} IS NOT NULL \
+                AND {ground_truth_col} IS NOT NULL \
                 GROUP BY ts order by ts desc \
                 """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_prediction_col = escape_identifier(prediction_col)
-        escaped_ground_truth_col = escape_identifier(ground_truth_col)
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts",
-            f"SUM(ABS({escaped_prediction_col} - {escaped_ground_truth_col})) as ae",
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
+            f"SUM(ABS({prediction_col} - {ground_truth_col})) as ae",
             f"COUNT(*) as count",
-        ] + escaped_segmentation_cols
-        all_group_by_cols = ["ts"] + escaped_segmentation_cols
+        ] + segmentation_cols
+        all_group_by_cols = ["ts"] + segmentation_cols
 
         # build query
         mae_query = f"""
             SELECT {", ".join(all_select_clause_cols)}
             FROM {dataset.dataset_table_name}
-            WHERE {escaped_prediction_col} IS NOT NULL
-                  AND {escaped_ground_truth_col} IS NOT NULL
+            WHERE {prediction_col} IS NOT NULL
+                  AND {ground_truth_col} IS NOT NULL
             GROUP BY {", ".join(all_group_by_cols)} order by ts desc
         """
 
         results = ddb_conn.sql(mae_query).df()
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         count_series = self.group_query_results_to_numeric_metrics(
             results,
             "count",
-            segmentation_cols,
+            unescaped_segmentation_cols,
             "ts",
         )
         absolute_error_series = self.group_query_results_to_numeric_metrics(
             results,
             "ae",
-            segmentation_cols,
+            unescaped_segmentation_cols,
             "ts",
         )
 

--- a/src/arthur_common/aggregations/functions/mean_squared_error.py
+++ b/src/arthur_common/aggregations/functions/mean_squared_error.py
@@ -19,7 +19,7 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier
+from arthur_common.tools.duckdb_data_loader import unescape_identifier
 
 
 class MeanSquaredErrorAggregationFunction(NumericAggregationFunction):
@@ -111,50 +111,45 @@ class MeanSquaredErrorAggregationFunction(NumericAggregationFunction):
         ] = None,
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
-                SELECT time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts, \
-                SUM(POW({escaped_prediction_col} - {escaped_ground_truth_col}, 2)) as squared_error, \
+                SELECT time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts, \
+                SUM(POW({prediction_col} - {ground_truth_col}, 2)) as squared_error, \
                 COUNT(*) as count \
                 FROM {dataset.dataset_table_name} \
-                WHERE {escaped_prediction_col} IS NOT NULL \
-                AND {escaped_ground_truth_col} IS NOT NULL \
+                WHERE {prediction_col} IS NOT NULL \
+                AND {ground_truth_col} IS NOT NULL \
                 GROUP BY ts order by ts desc \
                 """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_prediction_col = escape_identifier(prediction_col)
-        escaped_ground_truth_col = escape_identifier(ground_truth_col)
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts",
-            f"SUM(POW({escaped_prediction_col} - {escaped_ground_truth_col}, 2)) as squared_error",
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
+            f"SUM(POW({prediction_col} - {ground_truth_col}, 2)) as squared_error",
             f"COUNT(*) as count",
-        ] + escaped_segmentation_cols
-        all_group_by_cols = ["ts"] + escaped_segmentation_cols
+        ] + segmentation_cols
+        all_group_by_cols = ["ts"] + segmentation_cols
 
         # build query
         mse_query = f"""
             SELECT {", ".join(all_select_clause_cols)}
             FROM {dataset.dataset_table_name}
-            WHERE {escaped_prediction_col} IS NOT NULL
-                  AND {escaped_ground_truth_col} IS NOT NULL
+            WHERE {prediction_col} IS NOT NULL
+                  AND {ground_truth_col} IS NOT NULL
             GROUP BY {", ".join(all_group_by_cols)} order by ts desc
         """
 
         results = ddb_conn.sql(mse_query).df()
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
         count_series = self.group_query_results_to_numeric_metrics(
             results,
             "count",
-            segmentation_cols,
+            unescaped_segmentation_cols,
             "ts",
         )
         squared_error_series = self.group_query_results_to_numeric_metrics(
             results,
             "squared_error",
-            segmentation_cols,
+            unescaped_segmentation_cols,
             "ts",
         )
 

--- a/src/arthur_common/aggregations/functions/multiclass_confusion_matrix.py
+++ b/src/arthur_common/aggregations/functions/multiclass_confusion_matrix.py
@@ -20,7 +20,8 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier, escape_str_literal
+
+from arthur_common.tools.duckdb_data_loader import escape_str_literal, unescape_identifier
 
 
 class MulticlassClassifierStringLabelSingleClassConfusionMatrixAggregationFunction(
@@ -194,11 +195,11 @@ class MulticlassClassifierStringLabelSingleClassConfusionMatrixAggregationFuncti
             Returns the following SQL with no segmentation:
             WITH normalized_data AS (
                     SELECT
-                        {escaped_timestamp_col} AS timestamp,
-                        {prediction_normalization_case.replace('value', escaped_prediction_col)} AS prediction,
-                        {gt_normalization_case.replace('value', escaped_gt_values_col)} AS actual_value
+                        {timestamp_col} AS timestamp,
+                        {prediction_normalization_case.replace('value', prediction_col)} AS prediction,
+                        {gt_normalization_case.replace('value', gt_values_col)} AS actual_value
                     FROM {dataset.dataset_table_name}
-                    WHERE {escaped_timestamp_col} IS NOT NULL
+                    WHERE {timestamp_col} IS NOT NULL
                 )
                 SELECT
                     time_bucket(INTERVAL '5 minutes', timestamp) AS ts,
@@ -212,19 +213,12 @@ class MulticlassClassifierStringLabelSingleClassConfusionMatrixAggregationFuncti
                 ORDER BY ts
 
         """
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_prediction_col = escape_identifier(prediction_col)
-        escaped_gt_values_col = escape_identifier(gt_values_col)
-
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         first_subquery_select_cols = [
-            f"{escaped_timestamp_col} AS timestamp",
-            f"{prediction_normalization_case.replace('value', escaped_prediction_col)} AS prediction",
-            f"{gt_normalization_case.replace('value', escaped_gt_values_col)} AS actual_value",
-        ] + escaped_segmentation_cols
+            f"{timestamp_col} AS timestamp",
+            f"{prediction_normalization_case.replace('value', prediction_col)} AS prediction",
+            f"{gt_normalization_case.replace('value', gt_values_col)} AS actual_value",
+        ] + segmentation_cols
         second_subquery_select_cols = [
             "time_bucket(INTERVAL '5 minutes', timestamp) AS ts",
             "SUM(CASE WHEN prediction = 1 AND actual_value = 1 THEN 1 ELSE 0 END) AS true_positive_count",
@@ -232,8 +226,8 @@ class MulticlassClassifierStringLabelSingleClassConfusionMatrixAggregationFuncti
             "SUM(CASE WHEN prediction = 0 AND actual_value = 1 THEN 1 ELSE 0 END) AS false_negative_count",
             "SUM(CASE WHEN prediction = 0 AND actual_value = 0 THEN 1 ELSE 0 END) AS true_negative_count",
             f"any_value({escaped_positive_class_label}) as class_label",
-        ] + escaped_segmentation_cols
-        second_subquery_group_by_cols = ["ts"] + escaped_segmentation_cols
+        ] + segmentation_cols
+        second_subquery_group_by_cols = ["ts"] + segmentation_cols
         extra_dims = ["class_label"]
 
         # build query
@@ -241,7 +235,7 @@ class MulticlassClassifierStringLabelSingleClassConfusionMatrixAggregationFuncti
         WITH normalized_data AS (
             SELECT {", ".join(first_subquery_select_cols)}
             FROM {dataset.dataset_table_name}
-            WHERE {escaped_timestamp_col} IS NOT NULL
+            WHERE {timestamp_col} IS NOT NULL
         )
         SELECT {", ".join(second_subquery_select_cols)}
         FROM normalized_data
@@ -250,29 +244,30 @@ class MulticlassClassifierStringLabelSingleClassConfusionMatrixAggregationFuncti
 """
 
         results = ddb_conn.sql(confusion_matrix_query).df()
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
 
         tp = self.group_query_results_to_numeric_metrics(
             results,
             "true_positive_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         fp = self.group_query_results_to_numeric_metrics(
             results,
             "false_positive_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         fn = self.group_query_results_to_numeric_metrics(
             results,
             "false_negative_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         tn = self.group_query_results_to_numeric_metrics(
             results,
             "true_negative_count",
-            dim_columns=segmentation_cols + extra_dims,
+            dim_columns=unescaped_segmentation_cols + extra_dims,
             timestamp_col="ts",
         )
         tp_metric = self.series_to_metric(

--- a/src/arthur_common/aggregations/functions/numeric_stats.py
+++ b/src/arthur_common/aggregations/functions/numeric_stats.py
@@ -18,7 +18,8 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier, escape_str_literal
+
+from arthur_common.tools.duckdb_data_loader import unescape_identifier, escape_str_literal
 
 
 class NumericSketchAggregationFunction(SketchAggregationFunction):
@@ -95,41 +96,37 @@ class NumericSketchAggregationFunction(SketchAggregationFunction):
         ] = None,
     ) -> list[SketchMetric]:
         """Executed SQL with no segmentation columns:
-                    select {escaped_timestamp_col_id} as ts, \
-                       {escaped_numeric_col_id}, \
+                    select {timestamp_col} as ts, \
+                       {numeric_col}, \
                        {numeric_col_name_str} as column_name \
                 from {dataset.dataset_table_name} \
-                where {escaped_numeric_col_id} is not null \
+                where {numeric_col} is not null \
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col_id = escape_identifier(timestamp_col)
-        escaped_numeric_col_id = escape_identifier(numeric_col)
-        numeric_col_name_str = escape_str_literal(numeric_col)
+        numeric_col_name_str = escape_str_literal(unescape_identifier(numeric_col))
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"{escaped_timestamp_col_id} as ts",
-            f"{escaped_numeric_col_id}",
+            f"{timestamp_col} as ts",
+            f"{numeric_col}",
             f"{numeric_col_name_str} as column_name",
-        ] + escaped_segmentation_cols
+        ] + segmentation_cols
         extra_dims = ["column_name"]
 
         # build query
         data_query = f"""
                     select {", ".join(all_select_clause_cols)}
                     from {dataset.dataset_table_name}
-                    where {escaped_numeric_col_id} is not null
+                    where {numeric_col} is not null
                 """
 
         results = ddb_conn.sql(data_query).df()
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
 
         series = self.group_query_results_to_sketch_metrics(
             results,
-            numeric_col,
-            segmentation_cols + extra_dims,
+            unescape_identifier(numeric_col),
+            unescaped_segmentation_cols + extra_dims,
             "ts",
         )
 

--- a/src/arthur_common/aggregations/functions/numeric_sum.py
+++ b/src/arthur_common/aggregations/functions/numeric_sum.py
@@ -19,7 +19,7 @@ from arthur_common.models.schema_definitions import (
     ScalarType,
     ScopeSchemaTag,
 )
-from arthur_common.tools.duckdb_data_loader import escape_identifier
+from arthur_common.tools.duckdb_data_loader import unescape_identifier
 
 
 class NumericSumAggregationFunction(NumericAggregationFunction):
@@ -94,45 +94,41 @@ class NumericSumAggregationFunction(NumericAggregationFunction):
         ] = None,
     ) -> list[NumericMetric]:
         """Executed SQL with no segmentation columns:
-                select time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts, \
-                sum({escaped_numeric_col}) as sum \
+                select time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts, \
+                sum({numeric_col}) as sum \
                 from {dataset.dataset_table_name} \
-                where {escaped_numeric_col} is not null \
+                where {numeric_col} is not null \
                 group by ts \
         """
         segmentation_cols = [] if not segmentation_cols else segmentation_cols
-        escaped_timestamp_col = escape_identifier(timestamp_col)
-        escaped_numeric_col = escape_identifier(numeric_col)
 
         # build query components with segmentation columns
-        escaped_segmentation_cols = [
-            escape_identifier(col) for col in segmentation_cols
-        ]
         all_select_clause_cols = [
-            f"time_bucket(INTERVAL '5 minutes', {escaped_timestamp_col}) as ts",
-            f"sum({escaped_numeric_col}) as sum",
-        ] + escaped_segmentation_cols
-        all_group_by_cols = ["ts"] + escaped_segmentation_cols
+            f"time_bucket(INTERVAL '5 minutes', {timestamp_col}) as ts",
+            f"sum({numeric_col}) as sum",
+        ] + segmentation_cols
+        all_group_by_cols = ["ts"] + segmentation_cols
 
         # build query
         query = f"""
                     select {", ".join(all_select_clause_cols)}
                     from {dataset.dataset_table_name}
-                    where {escaped_numeric_col} is not null
+                    where {numeric_col} is not null
                     group by {", ".join(all_group_by_cols)}
                 """
 
         results = ddb_conn.sql(query).df()
+        unescaped_segmentation_cols = [unescape_identifier(seg_col) for seg_col in segmentation_cols]
 
         series = self.group_query_results_to_numeric_metrics(
             results,
             "sum",
-            segmentation_cols,
+            unescaped_segmentation_cols,
             "ts",
         )
         # preserve dimension that identifies the name of the numeric column used for the aggregation
         for point in series:
-            point.dimensions.append(Dimension(name="column_name", value=numeric_col))
+            point.dimensions.append(Dimension(name="column_name", value=unescape_identifier(numeric_col)))
 
         metric = self.series_to_metric(self.METRIC_NAME, series)
         return [metric]

--- a/src/arthur_common/tools/duckdb_data_loader.py
+++ b/src/arthur_common/tools/duckdb_data_loader.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import Any
 
 import duckdb
@@ -314,11 +315,40 @@ def escape_identifier(identifier: str) -> str:
     """
     Escape an identifier (e.g., column name) for use in a SQL query.
     This method handles special characters and ensures proper quoting.
+
+    For struct fields, the identifiers must be escaped as following:
+    "struct_column_name"."struct_field"
     """
     # Replace any double quotes with two double quotes
     escaped = identifier.replace('"', '""')
     # Wrap the entire identifier in double quotes and return
     return f'"{escaped}"'
+
+
+def unescape_identifier(identifier: str) -> str:
+    """
+    Unescape an identifier (e.g., column name).
+
+    This removes the double quotes and properly handles struct fields, which may be escaped as follows:
+    "struct_column_name"."struct_field"
+
+    Here's a hard case for help understanding this function: "struct "" column name with quotes"."struct.field.name.with.dots"
+    """
+    unescaped_identifiers = []
+    # strip top-level quotes
+    identifier = identifier[1:-1]
+    # split identifier into struct fields based on delimiter pattern "."
+    # at this point there are no external double quotes left; any remaining are escaped double quotes belonging to
+    # the column name
+    identifier_split_in_struct_fields = re.split(r'"\."', identifier)
+
+    for identifier in identifier_split_in_struct_fields:
+        # replace any escaped double quotes in the column
+        unescaped_identifier = identifier.replace('""', '"')
+        unescaped_identifiers.append(unescaped_identifier)
+
+    # join back any struct fields via dot syntax without the escape identifiers
+    return ".".join(unescaped_identifiers)
 
 
 def escape_str_literal(literal: str) -> str:

--- a/src/arthur_common/tools/duckdb_utils.py
+++ b/src/arthur_common/tools/duckdb_utils.py
@@ -16,17 +16,15 @@ def is_column_possible_segmentation(
     2. Has an allowed DType.
 
     PreReq: Table with column should already be loaded in DuckDB
+    column_name already has DuckDB escape identifier for the query syntax
     """
     segmentation_col_unique_val_limit = Config.segmentation_col_unique_values_limit()
     if column_dtype not in SEGMENTATION_ALLOWED_DTYPES:
         return False
 
-    # check column for unique value count
-    escaped_column = escape_identifier(column_name)
-
-    # count distinct values in this column
+    # check column for unique value count - count distinct values in this column
     distinct_count_query = f"""
-        SELECT COUNT(DISTINCT {escaped_column}) as distinct_count
+        SELECT COUNT(DISTINCT {column_name}) as distinct_count
         FROM {table}
     """
     result = conn.sql(distinct_count_query).fetchone()

--- a/src/arthur_common/tools/schema_inferer.py
+++ b/src/arthur_common/tools/schema_inferer.py
@@ -110,7 +110,7 @@ class SchemaInferer:
                 if not is_nested_col and is_column_possible_segmentation(
                     self.conn,
                     table,
-                    col_name,
+                    escape_identifier(col_name),
                     scalar_schema.dtype,
                 ):
                     scalar_schema.tag_hints.append(ScopeSchemaTag.POSSIBLE_SEGMENTATION)

--- a/tests/unit/aggregation_functions/test_categorical_count.py
+++ b/tests/unit/aggregation_functions/test_categorical_count.py
@@ -4,6 +4,7 @@ from arthur_common.aggregations.functions.categorical_count import (
     CategoricalCountAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -17,8 +18,8 @@ def test_string_categorical_count(
     metric = cat_counter.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="flight start",
-        categorical_col="customer feedback",
+        timestamp_col=escape_identifier("flight start"),
+        categorical_col=escape_identifier("customer feedback"),
     )
     assert len(metric) == 1
     assert metric[0].name == "categorical_count"
@@ -53,9 +54,9 @@ def test_cv_categorical_count_with_dimensions(
     metric = cat_counter.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="timestamp",
-        categorical_col="classification_pred",
-        segmentation_cols=["prompt_version_id"],
+        timestamp_col=escape_identifier("timestamp"),
+        categorical_col=escape_identifier("classification_pred"),
+        segmentation_cols=[escape_identifier("prompt_version_id")],
     )
     assert len(metric) == 1
     assert metric[0].name == "categorical_count"

--- a/tests/unit/aggregation_functions/test_confusion_matrix.py
+++ b/tests/unit/aggregation_functions/test_confusion_matrix.py
@@ -7,6 +7,7 @@ from arthur_common.aggregations.functions.confusion_matrix import (
     BinaryClassifierStringLabelConfusionMatrixAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -34,9 +35,9 @@ def test_int_bool_confusion_matrix(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=prediction_col,
-        gt_values_col="malicious",
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(prediction_col),
+        gt_values_col=escape_identifier("malicious"),
     )
     validate_expected_metric_names(cm_aggregator, metrics)
     assert len(metrics) == 4
@@ -54,10 +55,10 @@ def test_int_bool_confusion_matrix(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=prediction_col,
-        gt_values_col="malicious",
-        segmentation_cols=["packet type"],
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(prediction_col),
+        gt_values_col=escape_identifier("malicious"),
+        segmentation_cols=[escape_identifier("packet type")],
     )
     assert_dimension_in_metric(metrics[0], "packet type")
     # prediction column name should be included as a dimension
@@ -119,9 +120,9 @@ def test_str_label_confusion_matrix(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=f"{prediction_col} str label",
-        gt_values_col="malicious str label",
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(f"{prediction_col} str label"),
+        gt_values_col=escape_identifier("malicious str label"),
         true_label="MALICIOUS",
         false_label="NOT_MALICIOUS",
     )
@@ -147,12 +148,12 @@ def test_str_label_confusion_matrix(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=f"{prediction_col} str label",
-        gt_values_col="malicious str label",
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(f"{prediction_col} str label"),
+        gt_values_col=escape_identifier("malicious str label"),
         true_label="MALICIOUS",
         false_label="NOT_MALICIOUS",
-        segmentation_cols=["packet type"],
+        segmentation_cols=[escape_identifier("packet type")],
     )
     assert_dimension_in_metric(metrics[0], "packet type")
 
@@ -196,9 +197,9 @@ def test_prediction_threshold_confusion_matrix(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=f"{prediction_col} float value",
-        gt_values_col="malicious",
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(f"{prediction_col} float value"),
+        gt_values_col=escape_identifier("malicious"),
         threshold=0.93,
     )
     validate_expected_metric_names(cm_aggregator, metrics)
@@ -223,10 +224,10 @@ def test_prediction_threshold_confusion_matrix(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=f"{prediction_col} float value",
-        gt_values_col="malicious",
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(f"{prediction_col} float value"),
+        gt_values_col=escape_identifier("malicious"),
         threshold=0.93,
-        segmentation_cols=["packet type"],
+        segmentation_cols=[escape_identifier("packet type")],
     )
     assert_dimension_in_metric(metrics[0], "packet type")

--- a/tests/unit/aggregation_functions/test_count_by_class.py
+++ b/tests/unit/aggregation_functions/test_count_by_class.py
@@ -6,6 +6,7 @@ from arthur_common.aggregations.functions.inference_count_by_class import (
     BinaryClassifierCountThresholdClassAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference, Dimension
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -31,8 +32,8 @@ def test_int_bool_count_by_class(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=prediction_col,
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(prediction_col),
     )
     validate_expected_metric_names(cm_aggregator, metrics)
     assert len(metrics) == 1
@@ -52,9 +53,9 @@ def test_int_bool_count_by_class(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=prediction_col,
-        segmentation_cols=["packet type"],
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(prediction_col),
+        segmentation_cols=[escape_identifier("packet type")],
     )
     assert_dimension_in_metric(metrics[0], "packet type")
 
@@ -94,8 +95,8 @@ def test_prediction_threshold_count_by_class(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=f"{prediction_col} float value",
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(f"{prediction_col} float value"),
         threshold=0.93,
         true_label="yeetyeetyes",
         false_label="no",
@@ -119,12 +120,12 @@ def test_prediction_threshold_count_by_class(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="sent timestamp",
-        prediction_col=f"{prediction_col} float value",
+        timestamp_col=escape_identifier("sent timestamp"),
+        prediction_col=escape_identifier(f"{prediction_col} float value"),
         threshold=0.93,
         true_label="yeetyeetyes",
         false_label="no",
-        segmentation_cols=["packet type"],
+        segmentation_cols=[escape_identifier("packet type")],
     )
     assert_dimension_in_metric(metrics[0], "packet type")
     validate_expected_metric_names(cm_aggregator, metrics)

--- a/tests/unit/aggregation_functions/test_general_numerics.py
+++ b/tests/unit/aggregation_functions/test_general_numerics.py
@@ -12,6 +12,7 @@ from arthur_common.aggregations.functions.numeric_sum import (
     NumericSumAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -35,8 +36,8 @@ def test_inference_sum(
     metric = inference_sum.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="flight start",
-        numeric_col=column_name,
+        timestamp_col=escape_identifier("flight start"),
+        numeric_col=escape_identifier(column_name),
     )
     validate_expected_metric_names(inference_sum, metric)
     assert metric[0].name == "numeric_sum"
@@ -51,9 +52,9 @@ def test_inference_sum(
     metrics = inference_sum.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="flight start",
-        numeric_col=column_name,
-        segmentation_cols=["weather conditions"],
+        timestamp_col=escape_identifier("flight start"),
+        numeric_col=escape_identifier(column_name),
+        segmentation_cols=[escape_identifier("weather conditions")],
     )
     assert_dimension_in_metric(metrics[0], "weather conditions")
 
@@ -79,8 +80,8 @@ def test_inference_numeric_sketch(
     metrics = numeric_sketch_func.aggregate(
         conn,
         dataset_ref,
-        "flight start",
-        column_name,
+        escape_identifier("flight start"),
+        escape_identifier(column_name),
     )
     validate_expected_metric_names(numeric_sketch_func, metrics)
     assert len(metrics) == 1
@@ -110,8 +111,8 @@ def test_inference_numeric_sketch(
     metrics = numeric_sketch_func.aggregate(
         conn,
         dataset_ref,
-        "flight start",
-        column_name,
-        segmentation_cols=["weather conditions"],
+        escape_identifier("flight start"),
+        escape_identifier(column_name),
+        segmentation_cols=[escape_identifier("weather conditions")],
     )
     assert_dimension_in_metric(metrics[0], "weather conditions")

--- a/tests/unit/aggregation_functions/test_inference_count.py
+++ b/tests/unit/aggregation_functions/test_inference_count.py
@@ -4,6 +4,7 @@ from arthur_common.aggregations.functions.inference_count import (
     InferenceCountAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -15,7 +16,7 @@ def test_inference_count(
     # run test on balloons dataset
     conn, dataset_ref = get_balloons_dataset_conn
     inference_counter = InferenceCountAggregationFunction()
-    metrics = inference_counter.aggregate(conn, dataset_ref, "flight start")
+    metrics = inference_counter.aggregate(conn, dataset_ref, escape_identifier("flight start"))
     validate_expected_metric_names(inference_counter, metrics)
     assert len(metrics) == 1
     assert metrics[0].name == "inference_count"
@@ -33,8 +34,8 @@ def test_inference_count(
     metrics = inference_counter.aggregate(
         conn,
         dataset_ref,
-        "timestamp",
-        ["prompt_version_id"],
+        escape_identifier("timestamp"),
+        [escape_identifier("prompt_version_id")],
     )
     assert len(metrics) == 1
     assert metrics[0].name == "inference_count"

--- a/tests/unit/aggregation_functions/test_inference_null_counts.py
+++ b/tests/unit/aggregation_functions/test_inference_null_counts.py
@@ -5,6 +5,7 @@ from arthur_common.aggregations.functions.inference_null_count import (
     InferenceNullCountAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -37,8 +38,8 @@ def test_inference_null_count(
     metrics = inference_null_counter.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="flight start",
-        nullable_col=column_name,
+        timestamp_col=escape_identifier("flight start"),
+        nullable_col=escape_identifier(column_name),
     )
     validate_expected_metric_names(inference_null_counter, metrics)
     assert len(metrics) == 1
@@ -56,8 +57,8 @@ def test_inference_null_count(
     metrics = inference_null_counter.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="flight start",
-        nullable_col=column_name,
-        segmentation_cols=["weather conditions"],
+        timestamp_col=escape_identifier("flight start"),
+        nullable_col=escape_identifier(column_name),
+        segmentation_cols=[escape_identifier("weather conditions")],
     )
     assert_dimension_in_metric(metrics[0], "weather conditions")

--- a/tests/unit/aggregation_functions/test_mean_absolute_error.py
+++ b/tests/unit/aggregation_functions/test_mean_absolute_error.py
@@ -5,6 +5,7 @@ from arthur_common.aggregations.functions.mean_absolute_error import (
     MeanAbsoluteErrorAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -42,9 +43,9 @@ def test_mean_absolute_error(
     metrics = mae_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="timestamp",
-        prediction_col="expected energy consumption",
-        ground_truth_col="energy usage consumption",
+        timestamp_col=escape_identifier("timestamp"),
+        prediction_col=escape_identifier("expected energy consumption"),
+        ground_truth_col=escape_identifier("energy usage consumption"),
     )
     validate_expected_metric_names(mae_aggregator, metrics)
 
@@ -67,10 +68,10 @@ def test_mean_absolute_error(
     metrics = mae_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="timestamp",
-        prediction_col="expected energy consumption",
-        ground_truth_col="energy usage consumption",
-        segmentation_cols=["city"],
+        timestamp_col=escape_identifier("timestamp"),
+        prediction_col=escape_identifier("expected energy consumption"),
+        ground_truth_col=escape_identifier("energy usage consumption"),
+        segmentation_cols=[escape_identifier("city")],
     )
     assert_dimension_in_metric(metrics[0], "city")
     validate_expected_metric_names(mae_aggregator, metrics)

--- a/tests/unit/aggregation_functions/test_mean_squared_error.py
+++ b/tests/unit/aggregation_functions/test_mean_squared_error.py
@@ -5,6 +5,7 @@ from arthur_common.aggregations.functions.mean_squared_error import (
     MeanSquaredErrorAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -42,9 +43,9 @@ def test_mean_squared_error(
     metrics = mae_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="timestamp",
-        prediction_col="expected energy consumption",
-        ground_truth_col="energy usage consumption",
+        timestamp_col=escape_identifier("timestamp"),
+        prediction_col=escape_identifier("expected energy consumption"),
+        ground_truth_col=escape_identifier("energy usage consumption"),
     )
     validate_expected_metric_names(mae_aggregator, metrics)
 
@@ -65,10 +66,10 @@ def test_mean_squared_error(
     metrics = mae_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="timestamp",
-        prediction_col="expected energy consumption",
-        ground_truth_col="energy usage consumption",
-        segmentation_cols=["city"],
+        timestamp_col=escape_identifier("timestamp"),
+        prediction_col=escape_identifier("expected energy consumption"),
+        ground_truth_col=escape_identifier("energy usage consumption"),
+        segmentation_cols=[escape_identifier("city")],
     )
     assert_dimension_in_metric(metrics[0], "city")
     validate_expected_metric_names(mae_aggregator, metrics)

--- a/tests/unit/aggregation_functions/test_multiclass_confusion_matrix.py
+++ b/tests/unit/aggregation_functions/test_multiclass_confusion_matrix.py
@@ -5,6 +5,7 @@ from arthur_common.aggregations.functions.multiclass_confusion_matrix import (
     MulticlassClassifierStringLabelSingleClassConfusionMatrixAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -32,9 +33,9 @@ def test_multiclass_single_class_confusion_matrix(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="Timestamp",
-        prediction_col="PredictedLabel",
-        gt_values_col="TrueLabel",
+        timestamp_col=escape_identifier("Timestamp"),
+        prediction_col=escape_identifier("PredictedLabel"),
+        gt_values_col=escape_identifier("TrueLabel"),
         positive_class_label=positive_label,
     )
     validate_expected_metric_names(cm_aggregator, metrics)
@@ -83,11 +84,11 @@ def test_multiclass_with_segmentation(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="timestamp",
-        prediction_col="classification_pred",
-        gt_values_col="classification_gt",
+        timestamp_col=escape_identifier("timestamp"),
+        prediction_col=escape_identifier("classification_pred"),
+        gt_values_col=escape_identifier("classification_gt"),
         positive_class_label="functional",
-        segmentation_cols=["prompt_version_id"],
+        segmentation_cols=[escape_identifier("prompt_version_id")],
     )
     assert_dimension_in_metric(metrics[0], "prompt_version_id")
     validate_expected_metric_names(cm_aggregator, metrics)

--- a/tests/unit/aggregation_functions/test_multiclass_count_by_class.py
+++ b/tests/unit/aggregation_functions/test_multiclass_count_by_class.py
@@ -4,6 +4,7 @@ from arthur_common.aggregations.functions.multiclass_inference_count_by_class im
     MulticlassClassifierCountByClassAggregationFunction,
 )
 from arthur_common.models.metrics import DatasetReference
+from arthur_common.tools.duckdb_data_loader import escape_identifier
 
 from .helpers import *
 
@@ -17,8 +18,8 @@ def test_multiclass_str_count_by_class(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="Timestamp",
-        prediction_col="PredictedLabel",
+        timestamp_col=escape_identifier("Timestamp"),
+        prediction_col=escape_identifier("PredictedLabel"),
     )
     validate_expected_metric_names(cm_aggregator, metrics)
     assert len(metrics) == 1
@@ -50,9 +51,9 @@ def test_multiclass_str_count_by_class(
     metrics = cm_aggregator.aggregate(
         conn,
         dataset_ref,
-        timestamp_col="Timestamp",
-        prediction_col="classification_pred",
-        segmentation_cols=["prompt_version_id"],
+        timestamp_col=escape_identifier("Timestamp"),
+        prediction_col=escape_identifier("classification_pred"),
+        segmentation_cols=[escape_identifier("prompt_version_id")],
     )
     assert_dimension_in_metric(metrics[0], "prompt_version_id")
     validate_expected_metric_names(cm_aggregator, metrics)

--- a/tests/unit/tools/test_duckdb_data_loader.py
+++ b/tests/unit/tools/test_duckdb_data_loader.py
@@ -1,4 +1,6 @@
-from arthur_common.tools.duckdb_data_loader import escape_identifier, escape_str_literal
+import pytest
+
+from arthur_common.tools.duckdb_data_loader import escape_identifier, escape_str_literal, unescape_identifier
 
 
 def test_escape_identifier():
@@ -7,3 +9,21 @@ def test_escape_identifier():
 
 def test_escape_str_literal():
     assert escape_str_literal("foo'bar") == "'foo''bar'"
+
+
+@pytest.mark.parametrize(
+    'col_name_escaped, col_name_expected_unescaped',
+    [
+        ('"standard column"', 'standard column'),
+        ('"column.with.dots."', 'column.with.dots.'),
+        ('"struct_field.with.dots"."struct.nested.with.dots."', 'struct_field.with.dots.struct.nested.with.dots.'),
+        ('"one"."two"."three"', 'one.two.three'),
+        ('"column""with_escaped.quotes"', 'column"with_escaped.quotes'),
+        ('"nestedColEscapedQuotes"""."nestedQuote""Here"', 'nestedColEscapedQuotes".nestedQuote"Here'),
+        ('"on.""e"."two."""."""th.ree"', 'on."e.two."."th.ree'),
+    ],
+
+)
+def test_unescape_identifier(col_name_escaped: str, col_name_expected_unescaped: str) -> None:
+    unescaped_identifier = unescape_identifier(col_name_escaped)
+    assert unescaped_identifier == col_name_expected_unescaped


### PR DESCRIPTION
Jira ticket: https://arthurai.atlassian.net/browse/UP-2994

As part of support for nested columns, I decided to have the ML engine own the escape identifiers in the column arguments it passes to the aggregations. The reason for this is nested columns need to be formatted like the following using escape identifiers:
`"column_name"."struct_field"`.

Inside the aggregations themselves, we don't have access to the `Dataset` object that lives in the control plane. As such, we have no good way to figure out how to apply these escape identifiers on struct fields. 

This is already how custom aggregations worked; we wrote the escape identifiers in ourselves before executing the users' queries. This is because they require some knowledge of the dataset schema, which the ML engine has.

Let me know your thoughts!