### PR TITLE
remove class validators to move them to validate endpoint

### DIFF
--- a/src/arthur_common/models/metrics.py
+++ b/src/arthur_common/models/metrics.py
@@ -122,20 +122,6 @@ class BaseAggregationParameterSchema(BaseModel):
         description="Description of the parameter.",
     )
 
-    @field_validator("parameter_key")
-    @classmethod
-    def validate_parameter_key_allowed_characters(cls, v: str) -> str:
-        if not v.replace("_", "").isalpha():
-            raise ValueError("Parameter key can only contain letters and underscores.")
-        return v
-
-    @field_validator("friendly_name")
-    @classmethod
-    def validate_friendly_name_allowed_characters(cls, v: str) -> str:
-        if not v.replace("_", "").replace(" ", "").isalpha():
-            raise ValueError("Friendly name can only contain letters and underscores.")
-        return v
-
 
 class MetricsParameterSchema(BaseAggregationParameterSchema):
     # specific to default metrics/Python metrics—not available to custom aggregations
@@ -309,10 +295,3 @@ class ReportedCustomAggregation(BaseReportedAggregation):
     dimension_columns: list[str] = Field(
         description="Name of any dimension columns returned from the SQL query. Max length is 1.",
     )
-
-    @field_validator("dimension_columns")
-    @classmethod
-    def validate_dimension_columns_length(cls, v: list[str]) -> list[str]:
-        if len(v) > 1:
-            raise ValueError("Only one dimension column can be specified.")
-        return v


### PR DESCRIPTION
## Jira Ticket
https://arthurai.atlassian.net/browse/UP-3060

## Partner MR
https://gitlab.com/ArthurAI/arthur-scope/-/merge_requests/1369/diffs?commit_id=7419d45baf178fc8691f3bd9e76310a7653eab88

## Description
- This change removes the validators for checking parameter keys, friendly names and the number of dimension columns from the classes themselves
- We opted to move these validations to be checked during the call to {worspace_id}/validate_custom_aggregation endpoint