### PR TITLE
Add model_name field to various request and response schemas

### DIFF
--- a/src/arthur_common/models/request_schemas.py
+++ b/src/arthur_common/models/request_schemas.py
@@ -346,12 +346,20 @@ class PromptValidationRequest(BaseModel):
         description="The user ID this prompt belongs to",
         default=None,
     )
+    model_name: Optional[str] = Field(
+        description="The model name and version being used for this prompt (e.g., 'gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gemini-pro').",
+        default=None,
+    )
 
 
 class ResponseValidationRequest(BaseModel):
     response: str = Field(description="LLM Response to be validated by GenAI Engine")
     context: Optional[str] = Field(
         description="Optional data provided as context for the validation.",
+        default=None,
+    )
+    model_name: Optional[str] = Field(
+        description="The model name and version being used for this response (e.g., 'gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gemini-pro').",
         default=None,
     )
     # tokens: Optional[List[str]] = Field(description="optional, not used currently")

--- a/src/arthur_common/models/response_schemas.py
+++ b/src/arthur_common/models/response_schemas.py
@@ -185,6 +185,10 @@ class ValidationResult(BaseModel):
         description="The user ID this prompt belongs to",
         default=None,
     )
+    model_name: Optional[str] = Field(
+        description="The model name and version used for this validation (e.g., 'gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gemini-pro').",
+        default=None,
+    )
     model_config = ConfigDict(
         json_schema_extra={
             "example": {
@@ -215,6 +219,10 @@ class ExternalInferencePrompt(BaseModel):
     message: str
     prompt_rule_results: List[ExternalRuleResult]
     tokens: int | None = None
+    model_name: Optional[str] = Field(
+        description="The model name and version used for this prompt (e.g., 'gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gemini-pro').",
+        default=None,
+    )
 
 
 class ExternalInferenceResponse(BaseModel):
@@ -227,6 +235,10 @@ class ExternalInferenceResponse(BaseModel):
     context: Optional[str] = None
     response_rule_results: List[ExternalRuleResult]
     tokens: int | None = None
+    model_name: Optional[str] = Field(
+        description="The model name and version used for this response (e.g., 'gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gemini-pro').",
+        default=None,
+    )
 
 
 class InferenceFeedbackResponse(BaseModel):
@@ -297,6 +309,10 @@ class ExternalInference(BaseModel):
     inference_response: Optional[ExternalInferenceResponse] = None
     inference_feedback: List[InferenceFeedbackResponse]
     user_id: str | None = None
+    model_name: Optional[str] = Field(
+        description="The model name and version used for this inference (e.g., 'gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gemini-pro').",
+        default=None,
+    )
 
 
 class QueryInferencesResponse(BaseModel):
@@ -498,6 +514,10 @@ class ChatResponse(BaseModel):
     )
     response_results: List[ExternalRuleResult] = Field(
         description="list of rule results for the llm response",
+    )
+    model_name: Optional[str] = Field(
+        description="The model name and version used for this chat response (e.g., 'gpt-4', 'gpt-3.5-turbo', 'claude-3-opus', 'gemini-pro').",
+        default=None,
     )
 
 


### PR DESCRIPTION
This update introduces a new optional field, model_name, to the PromptValidationRequest, ResponseValidationRequest, and several other schemas. The field captures the model name and version being used, enhancing the context for validation and inference processes.

In support of: https://arthurai.atlassian.net/browse/UP-2977