### PR TITLE
add support for nested column segmentation

### DIFF
--- a/src/arthur_common/aggregations/aggregator.py
+++ b/src/arthur_common/aggregations/aggregator.py
@@ -35,6 +35,18 @@ class AggregationFunction(ABC):
         """Returns the list of aggregations reported by the aggregate function."""
         raise NotImplementedError
 
+    @staticmethod
+    def get_innermost_segmentation_columns(segmentation_cols: list[str]) -> list[str]:
+        """
+        Extracts the innermost column name for nested segmentation columns or 
+        returns the top-level column name for non-nested segmentation columns.
+        """
+        for i, col in enumerate(segmentation_cols):
+            nested_cols = col.split('.')
+            segmentation_cols[i] = nested_cols[-1]
+        
+        return segmentation_cols
+
     @abstractmethod
     def aggregate(
         self,
@@ -88,6 +100,9 @@ class NumericAggregationFunction(AggregationFunction, ABC):
                     timestamp_col,
                 ),
             ]
+
+        # get innermost column name for nested segmentation columns
+        dim_columns = AggregationFunction.get_innermost_segmentation_columns(dim_columns)
 
         calculated_metrics: list[NumericTimeSeries] = []
         # make sure dropna is False or rows with "null" as a dimension value will be dropped
@@ -168,6 +183,10 @@ class SketchAggregationFunction(AggregationFunction, ABC):
         """
 
         calculated_metrics: list[SketchTimeSeries] = []
+
+        # get innermost column name for nested segmentation columns
+        dim_columns = AggregationFunction.get_innermost_segmentation_columns(dim_columns)
+
         # make sure dropna is False or rows with "null" as a dimension value will be dropped
         groups = data.groupby(dim_columns, dropna=False)
         for _, group in groups:

--- a/src/arthur_common/tools/schema_inferer.py
+++ b/src/arthur_common/tools/schema_inferer.py
@@ -40,12 +40,11 @@ class SchemaInferer:
         self.conn.sql(
             f"CREATE OR REPLACE TEMP TABLE {escaped_col} AS SELECT UNNEST({escaped_col}) as {escaped_col} FROM {table}",
         )
-        return self._infer_schema(escaped_col, is_nested_col=True)
+        return self._infer_schema(escaped_col)
 
     def _infer_schema(
         self,
         table: str = "root",
-        is_nested_col: bool = False,
     ) -> DatasetObjectType:
         """is_nested_col indicates whether the function is being called on an unnested/flattened table that represents
         a struct column or list column in the root table."""
@@ -105,9 +104,7 @@ class SchemaInferer:
                         raise NotImplementedError(f"Type {col_type} not mappable.")
 
                 # tag column as a possible segmentation column if it meets criteria
-                # we only support top-level column aggregations right now (ie you can't aggregate on a nested column)
-                # so we don't want to tag nested columns as possible segmentation columns
-                if not is_nested_col and is_column_possible_segmentation(
+                if is_column_possible_segmentation(
                     self.conn,
                     table,
                     escape_identifier(col_name),

--- a/tests/unit/tools/test_schema_inference.py
+++ b/tests/unit/tools/test_schema_inference.py
@@ -106,7 +106,7 @@ def test_col_names_with_spaces_schema_inference():
         assert col.definition.tag_hints == []
         if isinstance(col.definition, DatasetObjectType):
             for obj in col.definition.object.values():
-                assert obj.tag_hints == []
+                assert obj.tag_hints == [ScopeSchemaTag.POSSIBLE_SEGMENTATION]
 
 
 def test_nested_schema_inference():


### PR DESCRIPTION
## Description
- Removes the requirements for 'not is_nested_col' from _infer_schema
- Adds a static function to the AggregationFunction class which extracts the inner-most column from a nested column (e.g. top_level.nested_col would return nested_col) since duckdb flattens out nested columns to only include the innermost one
- Adds calls to this new function for both Numeric and Sketch Aggregations

## Jira Ticket
https://arthurai.atlassian.net/browse/UP-3075

## Partner MRs
TBD