### PR TITLE
Add transform_version_id to ContinuousEvalResponse schema

### DIFF
--- a/src/arthur_common/models/task_eval_schemas.py
+++ b/src/arthur_common/models/task_eval_schemas.py
@@ -77,6 +77,10 @@ class ContinuousEvalResponse(BaseModel):
     llm_eval_name: str = Field(description="Name of the llm eval.")
     llm_eval_version: int = Field(description="Version of the llm eval.")
     transform_id: UUID = Field(description="ID of the transform.")
+    transform_version_id: Optional[UUID] = Field(
+        default=None,
+        description="ID of the pinned transform version. When set, the continuous eval will always execute using this version's configuration snapshot.",
+    )
     transform_variable_mapping: List[ContinuousEvalTransformVariableMappingResponse] = (
         Field(
             default_factory=list,

--- a/src/arthur_common/models/task_eval_schemas.py
+++ b/src/arthur_common/models/task_eval_schemas.py
@@ -136,9 +136,6 @@ class TraceTransformResponse(BaseModel):
         default=None,
         description="Description of the transform.",
     )
-    definition: TraceTransformDefinition = Field(
-        description="Transform definition specifying extraction rules.",
-    )
     created_at: datetime = Field(
         description="Timestamp representing the time of transform creation",
     )


### PR DESCRIPTION
Introduce an optional transform_version_id field to the ContinuousEvalResponse model, allowing for the specification of a pinned transform version for consistent evaluation configuration.