### PR TITLE
add id field to the audit log response id model

### DIFF
--- a/src/arthur_common/models/audit_log_schemas.py
+++ b/src/arthur_common/models/audit_log_schemas.py
@@ -14,6 +14,9 @@ class AuditLogPathParameter(BaseModel):
 
 class AuditLogResponseID(BaseModel):
     response_type: str = Field(description="The response model type")
+    id_field: str = Field(
+        default="id", description="The field the response ID was extracted from"
+    )
     response_id: Union[UUID, str] = Field(description="The ID of the response")
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "2026-04-07T17:28:59.944626Z"
+exclude-newer = "2026-04-14T15:28:00.48373Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -146,7 +146,7 @@ wheels = [
 
 [[package]]
 name = "arthur-common"
-version = "2.4.54"
+version = "2.4.55"
 source = { editable = "." }
 dependencies = [
     { name = "datasketches" },


### PR DESCRIPTION
## Description

Adds an id field parameter to the repsonse id object for audit logs

## Jira Ticket
- https://arthurai.atlassian.net/browse/UP-4208

## Partner MR
- https://github.com/arthur-ai/arthur-engine/pull/1600