### PR TITLE
feat: restoring definition field to TraceTransformResponse model

### DIFF
--- a/src/arthur_common/models/task_eval_schemas.py
+++ b/src/arthur_common/models/task_eval_schemas.py
@@ -135,6 +135,9 @@ class TraceTransformResponse(BaseModel):
         default=None,
         description="Description of the transform.",
     )
+    definition: TraceTransformDefinition = Field(
+        description="Latest version of the transform definition.",
+    )
     created_at: datetime = Field(
         description="Timestamp representing the time of transform creation",
     )


### PR DESCRIPTION
Restoring field `definition` to the `TraceTransformResponse` model, providing the latest version of the transform definition. This enhancement improves the schema's ability to convey transform details.