### PR TITLE
Fix Eval.config OpenAPI title to avoid naming collision in generated clients

### DIFF
--- a/src/arthur_common/models/task_eval_schemas.py
+++ b/src/arthur_common/models/task_eval_schemas.py
@@ -38,6 +38,7 @@ class Eval(BaseModel):
     )
     config: Optional[Union[LLMBaseConfigSettings, Dict[str, Any]]] = Field(
         default=None,
+        title="EvalConfig",
         description="Eval configuration. LLMBaseConfigSettings for LLM evals; type-specific dict for ML evals.",
     )
     created_at: datetime = Field(


### PR DESCRIPTION
## Summary
- Adds `title="EvalConfig"` to `Eval.config` field in `task_eval_schemas.py`
- Prevents naming collision when OpenAPI codegen generates the genai_client for ml-engine — previously both `Eval.config` and `NewRuleRequest.config` resolved to `"Config"`, causing the codegen to rename `NewRuleRequest.config` to `Config2`, breaking `api_client_type_converters.py`

## Test plan
- [ ] Verify generated ml-engine genai_client has `NewRuleRequest.config: Optional[Config]` (not `Config2`)
- [ ] ml-engine mypy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)