### PR TITLE
Bump urllib3 to 2.7.0 to fix security vulnerabilities

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-06-08T17:53:17.574724Z"
 exclude-newer-span = "P3D"
 
 [[package]]
@@ -201,8 +201,8 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0,<5" },
     { name = "pytest", specifier = ">=8.3.5,<9" },
     { name = "pytest-cov", specifier = ">=6.1.1,<7" },
-    { name = "responses", specifier = "==0.26.1" },
     { name = "pytest-xdist", specifier = "==3.8.0" },
+    { name = "responses", specifier = "==0.26.1" },
 ]
 linters = [
     { name = "autoflake", specifier = ">=2.3.1,<3" },
@@ -2262,11 +2262,11 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Upgrades the transitive `urllib3` dependency from 2.6.3 to 2.7.0 in `uv.lock` to resolve two open high-severity Dependabot alerts.

`urllib3` is pulled in transitively via `requests`, `responses`, and `types-requests` — it is not a direct dependency in `pyproject.toml`, so only the lockfile pin changes.

## Alerts fixed
- **GHSA-mf9v-mfxr-j63j** (high) — decompression-bomb safeguards bypassed in parts of the streaming API
- **GHSA-qccp-gfcp-xxvc** (high) — sensitive headers forwarded across origins in proxied low-level redirects

Both are patched in urllib3 2.7.0.

## Verification
- `uv lock --upgrade-package urllib3` → `urllib3 2.6.3 -> 2.7.0`
- `uv lock --check` passes
- `uv sync --all-groups` installs cleanly; `import urllib3` reports 2.7.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)